### PR TITLE
Fix for Python 3.11

### DIFF
--- a/klipper_repl/cli.py
+++ b/klipper_repl/cli.py
@@ -72,10 +72,10 @@ async def run(args):
             while True:
                 try:
                     with patch_stdout():
-                        finished, unfinished = await asyncio.wait([
+                        finished, unfinished = await asyncio.wait([asyncio.create_task(t) for t in [
                             session.prompt_async(f'{hostname}:{args.socket}* ', completer=completion, lexer=lexer),
                             disconnect_event.wait()
-                        ], return_when=asyncio.FIRST_COMPLETED)
+                        ]], return_when=asyncio.FIRST_COMPLETED)
 
                         if disconnect_event.is_set():
                             for task in unfinished:


### PR DESCRIPTION
On Python 3.11, `asyncio.wait` only works on Futures/Tasks:

```
  File "[...]/klipper-repl/klipper_repl/cli.py", line 75, in run
    finished, unfinished = await asyncio.wait([
                           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/tasks.py", line 415, in wait
    raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
TypeError: Passing coroutines is forbidden, use tasks explicitly.
```

This is a minimal fix, but I also tried another approach: [canceling the prompt task on disconnect](https://github.com/Piezoid/klipper-repl/commit/bf5a611b).